### PR TITLE
keyboard fix and password view option

### DIFF
--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -20,6 +20,15 @@ class _LoginViewState extends State<LoginView> {
   UserDataProvider _userDataProvider;
   StreamSubscription _sub;
 
+  bool _passwordObscured = true;
+
+  // Toggles the password show status
+  void _toggle() {
+    setState(() {
+      _passwordObscured = !_passwordObscured;
+    });
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -125,10 +134,19 @@ class _LoginViewState extends State<LoginView> {
             TextField(
               decoration: InputDecoration(
                 hintText: 'Password',
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    // Based on passwordObscured state choose the icon
+                    _passwordObscured ? Icons.visibility : Icons.visibility_off,
+                    color: Theme.of(context).primaryColorDark,
+                  ),
+                  onPressed: () => _toggle(),
+                ),
                 border: OutlineInputBorder(),
                 labelText: 'Password',
               ),
-              obscureText: true,
+              obscureText: _passwordObscured,
+              keyboardType: TextInputType.emailAddress,
               controller: _passwordTextFieldController,
             ),
             SizedBox(height: 20),


### PR DESCRIPTION
Zenhub Issues #1012 and #1013

- [x] Adds the email address keyboard layout to the password input keyboard, which includes @ . - _ 

The username keyboard was already set to the email address layout. 

- [x] Adds a view password option using an icon on the right side of the text field. This enables the viewer to toggle between seeing their password and not. 